### PR TITLE
Add convenience properties to match `parse-torrent`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,17 @@ The `parsed` magnet link object looks like this:
       "udp://tracker.ccc.de:80",
       "udp://open.demonii.com:1337"
     ],
-    "infoHash": "d2474e86c95b19b8bcfdb92bc12c9d44667cfa36" // added for convenience!
+
+    // added for convenience:
+    "infoHash": "d2474e86c95b19b8bcfdb92bc12c9d44667cfa36",
+    "name": "Leaves of Grass by Walt Whitman.epub",
+    "announce": [
+      "udp://tracker.openbittorrent.com:80",
+      "udp://tracker.publicbt.com:80",
+      "udp://tracker.istole.it:6969",
+      "udp://tracker.ccc.de:80",
+      "udp://open.demonii.com:1337"
+    ]
   }
 ```
 

--- a/index.js
+++ b/index.js
@@ -48,8 +48,18 @@ module.exports = function (uri) {
     result.infoHash = new Buffer(m[1], 'hex').toString('hex')
   } else if (result.xt && (m = result.xt.match(/^urn:btih:(.{32})/))) {
     var decodedStr = base32.decode(m[1])
-    result.infoHash = new Buffer(decodedStr, 'binary').toString('hex');
+    result.infoHash = new Buffer(decodedStr, 'binary').toString('hex')
   }
+
+  // Convenience properties to match parse-torrent results. 
+  // Maybe in the future we could simply ignore 'minified' properties.
+  if (result.dn) result.name = decodeURIComponent(result.dn).replace('+', ' ')
+  if (result.kt) result.keywords = decodeURIComponent(result.kt).split('+')
+  if (result.tr) result.announce = result.tr
+  //if (result.mt) // TODO: link to the metafile that contains a list of magneto (MAGMA – MAGnet MAnifest)
+  //if (result.xl) // TODO: xl (eXact Length) – Size in bytes
+  //if (result.as) // TODO: as (Acceptable Source) – Web link to the file online
+  //if (result.xs) // TODO: xs (eXact Source) – P2P link.
 
   return result
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -7,18 +7,17 @@ test('parse valid magnet uris', function (t) {
   t.doesNotThrow(function () {
     magnet(leavesOfGrass)
   })
-  t.deepEquals(magnet(leavesOfGrass), {
-    "xt": "urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36",
-    "infoHash": "d2474e86c95b19b8bcfdb92bc12c9d44667cfa36",
-    "dn": "Leaves+of+Grass+by+Walt+Whitman.epub",
-    "tr": [
+  result = magnet(leavesOfGrass)
+  t.equal(result.xt, "urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36")
+  t.equal(result.dn, "Leaves+of+Grass+by+Walt+Whitman.epub")
+  t.equal(result.infoHash, "d2474e86c95b19b8bcfdb92bc12c9d44667cfa36")
+  t.deepEquals(result.tr, [
       "udp://tracker.openbittorrent.com:80",
       "udp://tracker.publicbt.com:80",
       "udp://tracker.istole.it:6969",
       "udp://tracker.ccc.de:80",
       "udp://open.demonii.com:1337"
-    ]
-  })
+  ])
   t.end()
 })
 
@@ -85,5 +84,11 @@ test('extracts 20-char hex BitTorrent info_hash', function (t) {
 test('extracts 32-char base32 BitTorrent info_hash', function (t) {
   result = magnet('magnet:?xt=urn:btih:64DZYZWMUAVLIWJUXGDIK4QGAAIN7SL6')
   t.equal(result.infoHash, 'f7079c66cca02ab45934b9868572060010dfc97e')
+  t.end()
+})
+
+test('extracts keywords', function (t) {
+  result = magnet('magnet:?xt=urn:btih:64DZYZWMUAVLIWJUXGDIK4QGAAIN7SL6&kt=joe+blow+mp3')
+  t.deepEqual(result.keywords, ['joe','blow','mp3'])
   t.end()
 })


### PR DESCRIPTION
Added some convenience result properties to match `parse-torrent`

I think, in the future, could be good to deprecate 'minified' properties
(dn, kt, tr) and automatically parse them.
