### PR TITLE
Add support for publicKey from BEP46

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ magnet:?xt=urn:ed2k:354B15E68FB8F36D7CD88FF94116CDC1&xt=urn:tree:tiger:7N5OAMRNG
 ```
 
 You can also use convenience key names like `name` (`dn`), `infoHash` (`xt`),
-`infoHashBuffer` (`xt`), `announce` (`tr`), and `keywords` (`kt`).
+`infoHashBuffer` (`xt`), `publicKey` (`xs`), `publicKeyBuffer` (`xs`), `announce` (`tr`), and `keywords` (`kt`).
 
 ## license
 

--- a/index.js
+++ b/index.js
@@ -73,7 +73,6 @@ function magnetURIDecode (uri) {
   if (result.xs) {
     const xss = Array.isArray(result.xs) ? result.xs : [result.xs]
     xss.forEach(xs => {
-      console.log({xs})
       if ((m = xs.match(/^urn:btpk:(.{64})/))) {
         result.publicKey = m[1]
       }

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function magnetURIDecode (uri) {
     const xss = Array.isArray(result.xs) ? result.xs : [result.xs]
     xss.forEach(xs => {
       if ((m = xs.match(/^urn:btpk:(.{64})/))) {
-        result.publicKey = m[1]
+        result.publicKey = m[1].toLowerCase()
       }
     })
   }
@@ -134,7 +134,7 @@ function magnetURIEncode (obj) {
           val = encodeURIComponent(val)
         }
         // Don't URI encode BEP46 keys
-        if (key === 'xs' && !val.startsWith('urn:btpk')) {
+        if (key === 'xs' && !val.startsWith('urn:btpk:')) {
           val = encodeURIComponent(val)
         }
         if (key === 'kt') val = encodeURIComponent(val)

--- a/index.js
+++ b/index.js
@@ -69,7 +69,19 @@ function magnetURIDecode (uri) {
       }
     })
   }
+
+  if (result.xs) {
+    const xss = Array.isArray(result.xs) ? result.xs : [result.xs]
+    xss.forEach(xs => {
+      console.log({xs})
+      if ((m = xs.match(/^urn:btpk:(.{64})/))) {
+        result.publicKey = m[1]
+      }
+    })
+  }
+
   if (result.infoHash) result.infoHashBuffer = Buffer.from(result.infoHash, 'hex')
+  if (result.publicKey) result.publicKeyBuffer = Buffer.from(result.publicKey, 'hex')
 
   if (result.dn) result.name = result.dn
   if (result.kt) result.keywords = result.kt
@@ -100,6 +112,8 @@ function magnetURIEncode (obj) {
   // (example: `infoHash` for `xt`, `name` for `dn`)
   if (obj.infoHashBuffer) obj.xt = `urn:btih:${obj.infoHashBuffer.toString('hex')}`
   if (obj.infoHash) obj.xt = `urn:btih:${obj.infoHash}`
+  if (obj.publicKeyBuffer) obj.xs = `urn:btpk:${obj.publicKeyBuffer.toString('hex')}`
+  if (obj.publicKey) obj.xs = `urn:btpk:${obj.publicKey}`
   if (obj.name) obj.dn = obj.name
   if (obj.keywords) obj.kt = obj.keywords
   if (obj.announce) obj.tr = obj.announce
@@ -117,7 +131,11 @@ function magnetURIEncode (obj) {
         if ((i > 0 || j > 0) && (key !== 'kt' || j === 0)) result += '&'
 
         if (key === 'dn') val = encodeURIComponent(val).replace(/%20/g, '+')
-        if (key === 'tr' || key === 'xs' || key === 'as' || key === 'ws') {
+        if (key === 'tr' || key === 'as' || key === 'ws') {
+          val = encodeURIComponent(val)
+        }
+        // Don't URI encode BEP46 keys
+        if (key === 'xs' && !val.startsWith('urn:btpk')) {
           val = encodeURIComponent(val)
         }
         if (key === 'kt') val = encodeURIComponent(val)

--- a/test/decode.js
+++ b/test/decode.js
@@ -138,7 +138,7 @@ test('Cast file index (ix) to a number', t => {
 })
 
 test('decode: Extracts public key from xs', t => {
-	const key = '9a36edf0988ddc1a0fc02d4e8652cce87a71aaac71fce936e650a597c0fb72e0'
+  const key = '9a36edf0988ddc1a0fc02d4e8652cce87a71aaac71fce936e650a597c0fb72e0'
   const result = magnet(`magnet:?xs=urn:btpk:${key}`)
   t.equal(result.publicKey, key)
   t.deepEqual(result.publicKeyBuffer, Buffer.from(key, 'hex'))

--- a/test/decode.js
+++ b/test/decode.js
@@ -136,3 +136,11 @@ test('Cast file index (ix) to a number', t => {
   t.equal(result.ix, 1)
   t.end()
 })
+
+test('decode: Extracts public key from xs', t => {
+	const key = '9a36edf0988ddc1a0fc02d4e8652cce87a71aaac71fce936e650a597c0fb72e0'
+  const result = magnet(`magnet:?xs=urn:btpk:${key}`)
+  t.equal(result.publicKey, key)
+  t.deepEqual(result.publicKeyBuffer, Buffer.from(key, 'hex'))
+  t.end()
+})

--- a/test/encode.js
+++ b/test/encode.js
@@ -77,3 +77,23 @@ test('encode: using infoHashBuffer', t => {
   })
   t.end()
 })
+
+test('encode: using publicKey', t => {
+  const publicKey = '9a36edf0988ddc1a0fc02d4e8652cce87a71aaac71fce936e650a597c0fb72e0'
+  const obj = {
+    publicKey
+  }
+  const result = magnet.encode(obj)
+  t.equal(result, 'magnet:?xs=urn:btpk:9a36edf0988ddc1a0fc02d4e8652cce87a71aaac71fce936e650a597c0fb72e0')
+  t.end()
+})
+
+test('encode: using publicKeyBuffer', t => {
+  const publicKeyBuffer = Buffer.from('9a36edf0988ddc1a0fc02d4e8652cce87a71aaac71fce936e650a597c0fb72e0', 'hex')
+  const obj = {
+    publicKeyBuffer
+  }
+  const result = magnet.encode(obj)
+  t.equal(result, 'magnet:?xs=urn:btpk:9a36edf0988ddc1a0fc02d4e8652cce87a71aaac71fce936e650a597c0fb72e0')
+  t.end()
+})


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

- Added encode/decode rules for `xs=urn:btpk:PUBLIC_KEY` to parse out a `publicKey` based on [BEP 46](http://bittorrent.org/beps/bep_0046.html)
- Encoding got modified to only use URI encode for `xs` strings that don't start with `urn:btpk:`

**Which issue (if any) does this pull request address?**

This will make life easier for me in [mutable-webtorrent](https://github.com/RangerMauve/mutable-webtorrent)

**Is there anything you'd like reviewers to focus on?**
