### PR TITLE
Implement Magnet URI extension (BEP53)

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function magnetURIDecode (uri) {
 
     // Address tracker (tr), exact source (xs), and acceptable source (as) are encoded
     // URIs, so decode them
-    if (key === 'tr' || key === 'xs' || key === 'as' || key === 'ws') {
+    if (key === 'tr' || key === 'xs' || key === 'as' || key === 'ws' || key === 'so') {
       val = decodeURIComponent(val)
     }
 
@@ -118,6 +118,7 @@ function magnetURIEncode (obj) {
         if ((i > 0 || j > 0) && (key !== 'kt' || j === 0)) result += '&'
 
         if (key === 'dn') val = encodeURIComponent(val).replace(/%20/g, '+')
+        if (key === 'so') val = encodeURIComponent(val).replace(/%2C/g, ',')
         if (key === 'tr' || key === 'xs' || key === 'as' || key === 'ws') {
           val = encodeURIComponent(val)
         }

--- a/test/decode.js
+++ b/test/decode.js
@@ -136,3 +136,10 @@ test('Cast file index (ix) to a number', t => {
   t.equal(result.ix, 1)
   t.end()
 })
+
+// Select specific file indices for download (BEP53) http://www.bittorrent.org/beps/bep_0053.html
+test('decode: select-only', t => {
+  const result = magnet('magnet:?xt=urn:btih:64DZYZWMUAVLIWJUXGDIK4QGAAIN7SL6&so=0,2,4,6-8')
+  t.equal(result.so, '0,2,4,6-8')
+  t.end()
+})

--- a/test/encode.js
+++ b/test/encode.js
@@ -77,3 +77,22 @@ test('encode: using infoHashBuffer', t => {
   })
   t.end()
 })
+
+// Select specific file indices for download (BEP53) http://www.bittorrent.org/beps/bep_0053.html
+test('encode: select-only', t => {
+  const obj = {
+    xt: 'urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+    so: '0,2,4,6-8'
+  }
+  const result = magnet.encode(obj)
+  t.equal(result, 'magnet:?xt=urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36&so=0,2,4,6-8')
+  t.deepEqual(magnet.decode(result), {
+    xt: 'urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+    infoHash: 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+    infoHashBuffer: Buffer.from('d2474e86c95b19b8bcfdb92bc12c9d44667cfa36', 'hex'),
+    urlList: [],
+    announce: [],
+    so: '0,2,4,6-8'
+  })
+  t.end()
+})


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

I've added Magnet URI extension [BEP53](http://bittorrent.org/beps/bep_0053.html) implementation.

**Which issue (if any) does this pull request address?**

Although currently webtorrent does support BEP53 throw https://github.com/webtorrent/webtorrent/pull/1396 without this PR it is not possible to load a "select only" magnet as described in https://github.com/webtorrent/webtorrent-desktop/issues/1852 

**Is there anything you'd like reviewers to focus on?**
