### PR TITLE
Implement Magnet URI extension (BEP53)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/webtorrent/magnet-uri/issues"
   },
   "dependencies": {
-    "thirty-two": "^1.0.2"
+    "thirty-two": "^1.0.2",
+    "bep53-range": "^1.0.0"
   },
   "devDependencies": {
     "standard": "*",

--- a/test/decode.js
+++ b/test/decode.js
@@ -136,3 +136,10 @@ test('Cast file index (ix) to a number', t => {
   t.equal(result.ix, 1)
   t.end()
 })
+
+// Select specific file indices for download (BEP53) http://www.bittorrent.org/beps/bep_0053.html
+test('decode: select-only', t => {
+  const result = magnet('magnet:?xt=urn:btih:64DZYZWMUAVLIWJUXGDIK4QGAAIN7SL6&so=0,2,4,6-8')
+  t.deepEqual(result.so, [0, 2, 4, 6, 7, 8])
+  t.end()
+})

--- a/test/encode.js
+++ b/test/encode.js
@@ -77,3 +77,22 @@ test('encode: using infoHashBuffer', t => {
   })
   t.end()
 })
+
+// Select specific file indices for download (BEP53) http://www.bittorrent.org/beps/bep_0053.html
+test('encode: select-only', t => {
+  const obj = {
+    xt: 'urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+    so: [0, 2, 4, 6, 7, 8]
+  }
+  const result = magnet.encode(obj)
+  t.equal(result, 'magnet:?xt=urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36&so=0,2,4,6-8')
+  t.deepEqual(magnet.decode(result), {
+    xt: 'urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+    infoHash: 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+    infoHashBuffer: Buffer.from('d2474e86c95b19b8bcfdb92bc12c9d44667cfa36', 'hex'),
+    urlList: [],
+    announce: [],
+    so: [0, 2, 4, 6, 7, 8]
+  })
+  t.end()
+})


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
I've added Magnet URI extension [BEP53](http://bittorrent.org/beps/bep_0053.html) implementation.

**Which issue (if any) does this pull request address?**
Although currently webtorrent does support BEP53 throw webtorrent/webtorrent#1396 without this PR it is not possible to load a "select only" magnet as described in webtorrent/webtorrent-desktop#1852

**Is there anything you'd like reviewers to focus on?**
In this implementation I've used https://github.com/hicom150/bep53-range instead of `parse-numeric-range` as can both `parse` and `compose` valid bep53 ranges.

My idea is to transfer https://github.com/hicom150/bep53-range to `webtorrent` organization but I want to ask @feross his approval 😉