### PR TITLE
Add .github/ to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
+.github/
 .travis.yml
 test/


### PR DESCRIPTION
This prevents npm from publishing `.github/` to npm registry and pointlessly downloading it for every dependent of this package.

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain:

**What changes did you make? (Give an overview)**
Instructed npm to ignore files `.github`, which are not needed by dependents of this package. As of now, the savings are negligible (<500 bytes).

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
