### PR TITLE
Support SHA-256 hashes in xt

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,8 @@ function magnetURIDecode (uri) {
       } else if ((m = xt.match(/^urn:btih:(.{32})/))) {
         const decodedStr = base32.decode(m[1])
         result.infoHash = Buffer.from(decodedStr, 'binary').toString('hex')
+      } else if ((m = xt.match(/^urn:btmh:1220(.{64})/))) {
+        result.infoHashV2 = m[1].toLowerCase()
       }
     })
   }
@@ -85,6 +87,7 @@ function magnetURIDecode (uri) {
   }
 
   if (result.infoHash) result.infoHashBuffer = Buffer.from(result.infoHash, 'hex')
+  if (result.infoHashV2) result.infoHashV2Buffer = Buffer.from(result.infoHashV2, 'hex')
   if (result.publicKey) result.publicKeyBuffer = Buffer.from(result.publicKey, 'hex')
 
   if (result.dn) result.name = result.dn
@@ -121,8 +124,19 @@ function magnetURIEncode (obj) {
 
   // support using convenience names, in addition to spec names
   // (example: `infoHash` for `xt`, `name` for `dn`)
-  if (obj.infoHashBuffer) obj.xt = `urn:btih:${obj.infoHashBuffer.toString('hex')}`
-  if (obj.infoHash) obj.xt = `urn:btih:${obj.infoHash}`
+
+  // Deduplicate xt by using a set
+  let xts = new Set()
+  if (obj.xt && typeof obj.xt === 'string') xts.add(obj.xt)
+  if (obj.xt && typeof obj.xt === 'object') xts = new Set(obj.xt)
+  if (obj.infoHashBuffer) xts.add(`urn:btih:${obj.infoHashBuffer.toString('hex')}`)
+  if (obj.infoHash) xts.add(`urn:btih:${obj.infoHash}`)
+  if (obj.infoHashV2Buffer) xts.add(obj.xt = `urn:btmh:1220${obj.infoHashV2Buffer.toString('hex')}`)
+  if (obj.infoHashV2) xts.add(`urn:btmh:1220${obj.infoHashV2}`)
+  const xtsDeduped = Array.from(xts)
+  if (xtsDeduped.length === 1) obj.xt = xtsDeduped[0]
+  if (xtsDeduped.length > 1) obj.xt = xtsDeduped
+
   if (obj.publicKeyBuffer) obj.xs = `urn:btpk:${obj.publicKeyBuffer.toString('hex')}`
   if (obj.publicKey) obj.xs = `urn:btpk:${obj.publicKey}`
   if (obj.name) obj.dn = obj.name

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function magnetURIEncode (obj) {
   // Deduplicate xt by using a set
   let xts = new Set()
   if (obj.xt && typeof obj.xt === 'string') xts.add(obj.xt)
-  if (obj.xt && typeof obj.xt === 'object') xts = new Set(obj.xt)
+  if (obj.xt && Array.isArray(obj.xt)) xts = new Set(obj.xt)
   if (obj.infoHashBuffer) xts.add(`urn:btih:${obj.infoHashBuffer.toString('hex')}`)
   if (obj.infoHash) xts.add(`urn:btih:${obj.infoHash}`)
   if (obj.infoHashV2Buffer) xts.add(obj.xt = `urn:btmh:1220${obj.infoHashV2Buffer.toString('hex')}`)

--- a/test/decode.js
+++ b/test/decode.js
@@ -1,15 +1,21 @@
 const magnet = require('../')
 const test = require('tape')
 
-const leavesOfGrass = 'magnet:?xt=urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36&dn=Leaves+of+Grass+by+Walt+Whitman.epub&tr=udp%3A%2F%2Ftracker.example4.com%3A80&tr=udp%3A%2F%2Ftracker.example5.com%3A80&tr=udp%3A%2F%2Ftracker.example3.com%3A6969&tr=udp%3A%2F%2Ftracker.example2.com%3A80&tr=udp%3A%2F%2Ftracker.example1.com%3A1337'
+const leavesOfGrass = 'magnet:?xt=urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36&xt=urn:btmh:1220d2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b&dn=Leaves+of+Grass+by+Walt+Whitman.epub&tr=udp%3A%2F%2Ftracker.example4.com%3A80&tr=udp%3A%2F%2Ftracker.example5.com%3A80&tr=udp%3A%2F%2Ftracker.example3.com%3A6969&tr=udp%3A%2F%2Ftracker.example2.com%3A80&tr=udp%3A%2F%2Ftracker.example1.com%3A1337'
 
 const empty = { announce: [], urlList: [], peerAddresses: [] }
 
 test('decode: valid magnet uris', t => {
   const result = magnet(leavesOfGrass)
-  t.equal(result.xt, 'urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36')
   t.equal(result.dn, 'Leaves of Grass by Walt Whitman.epub')
   t.equal(result.infoHash, 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36')
+  t.equal(result.infoHashV2, 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b')
+
+  const xt = [
+    'urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+    'urn:btmh:1220d2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b'
+  ]
+
   const announce = [
     'udp://tracker.example1.com:1337',
     'udp://tracker.example2.com:80',
@@ -19,6 +25,7 @@ test('decode: valid magnet uris', t => {
   ]
 
   // sort so that order doesn't matter
+  t.deepEqual(result.xt.sort(), xt.sort())
   t.deepEqual(result.tr.sort(), announce.sort())
   t.deepEqual(result.announce.sort(), announce.sort())
 
@@ -47,10 +54,12 @@ test('decode: invalid magnet URIs return empty object', t => {
   const invalid1 = 'magnet:?xt=urn:btih:==='
   const invalid2 = 'magnet:?xt'
   const invalid3 = 'magnet:?xt=?dn='
+  const invalid4 = 'magnet:?xt=urn:btmh:==='
 
   t.deepEqual(magnet(invalid1), empty)
   t.deepEqual(magnet(invalid2), empty)
   t.deepEqual(magnet(invalid3), empty)
+  t.deepEqual(magnet(invalid4), empty)
   t.end()
 })
 
@@ -74,6 +83,13 @@ test('decode: extracts 40-char hex BitTorrent info_hash', t => {
 test('decode: extracts 32-char base32 BitTorrent info_hash', t => {
   const result = magnet('magnet:?xt=urn:btih:64DZYZWMUAVLIWJUXGDIK4QGAAIN7SL6')
   t.equal(result.infoHash, 'f7079c66cca02ab45934b9868572060010dfc97e')
+  t.end()
+})
+
+test('decode: extracts 64-char hex BitTorrent V2 info_hash', t => {
+  const result = magnet('magnet:?xt=urn:btmh:122080e00d84343afd2b6392e966c1267807461946ba9db1d5af4bb50779dcf1ab4e')
+  t.equal(result.infoHash, undefined)
+  t.equal(result.infoHashV2, '80e00d84343afd2b6392e966c1267807461946ba9db1d5af4bb50779dcf1ab4e')
   t.end()
 })
 

--- a/test/encode.js
+++ b/test/encode.js
@@ -26,11 +26,16 @@ test('encode: complicated magnet uri (multiple xt params, and as, xs)', t => {
 
 test('encode: simple magnet uri using convenience names', t => {
   const obj = {
-    xt: 'urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+    xt: [
+      'urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+      'urn:btmh:1220d2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b'
+    ],
     dn: 'Leaves of Grass by Walt Whitman.epub',
     name: 'Leaves of Grass by Walt Whitman.epub',
     infoHash: 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
     infoHashBuffer: Buffer.from('d2474e86c95b19b8bcfdb92bc12c9d44667cfa36', 'hex'),
+    infoHashV2: 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b',
+    infoHashV2Buffer: Buffer.from('d2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b', 'hex'),
     tr: [
       'udp://tracker.example1.com:1337',
       'udp://tracker.example2.com:80',
@@ -56,7 +61,7 @@ test('encode: simple magnet uri using convenience names', t => {
 
   const result = magnet.encode(obj)
 
-  t.equal(result, 'magnet:?xt=urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36&dn=Leaves+of+Grass+by+Walt+Whitman.epub&tr=udp%3A%2F%2Ftracker.example1.com%3A1337&tr=udp%3A%2F%2Ftracker.example2.com%3A80&tr=udp%3A%2F%2Ftracker.example3.com%3A6969&tr=udp%3A%2F%2Ftracker.example4.com%3A80&tr=udp%3A%2F%2Ftracker.example5.com%3A80&ws=http%3A%2F%2Fdownload.wikimedia.org%2Fmediawiki%2F1.15%2Fmediawiki-1.15.1.tar.gz&kt=hey+hey2')
+  t.equal(result, 'magnet:?xt=urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36&xt=urn:btmh:1220d2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b&dn=Leaves+of+Grass+by+Walt+Whitman.epub&tr=udp%3A%2F%2Ftracker.example1.com%3A1337&tr=udp%3A%2F%2Ftracker.example2.com%3A80&tr=udp%3A%2F%2Ftracker.example3.com%3A6969&tr=udp%3A%2F%2Ftracker.example4.com%3A80&tr=udp%3A%2F%2Ftracker.example5.com%3A80&ws=http%3A%2F%2Fdownload.wikimedia.org%2Fmediawiki%2F1.15%2Fmediawiki-1.15.1.tar.gz&kt=hey+hey2')
 
   t.deepEqual(magnet.decode(result), obj)
 
@@ -73,6 +78,23 @@ test('encode: using infoHashBuffer', t => {
     infoHashBuffer: Buffer.from('d2474e86c95b19b8bcfdb92bc12c9d44667cfa36', 'hex'),
     infoHash: 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
     xt: 'urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+    urlList: [],
+    announce: [],
+    peerAddresses: []
+  })
+  t.end()
+})
+
+test('encode: using infoHashV2Buffer', t => {
+  const obj = {
+    infoHashV2Buffer: Buffer.from('d2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b', 'hex')
+  }
+  const result = magnet.encode(obj)
+  t.equal(result, 'magnet:?xt=urn:btmh:1220d2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b')
+  t.deepEqual(magnet.decode(result), {
+    infoHashV2: 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b',
+    infoHashV2Buffer: Buffer.from('d2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b', 'hex'),
+    xt: 'urn:btmh:1220d2474e86c95b19b8bcfdb92bc12c9d44667cfa36d2474e86c95b19b8bcfdb92b',
     urlList: [],
     announce: [],
     peerAddresses: []


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Added ability to parse and encode BitTorrent V2 xt hashes. These are SHA-256 hashes written in [multi-hash](https://github.com/multiformats/multihash) format.

**Which issue (if any) does this pull request address?**
This improves compatibility with BitTorrent V2.

**Is there anything you'd like reviewers to focus on?**
This adds two new attributes to the output object, `infoHashV1` (which is an alias to `infoHash`) and `infoHashV2`. If you would like to store the data in some other way, I'll gladly edit this patch accordingly.

You might find the following sources helpful:
 - [libtorrent blog "Bittorrent v2"](https://blog.libtorrent.org/2020/09/bittorrent-v2/)
 - [libtorrent/src/magnet_uri.cpp](https://github.com/arvidn/libtorrent/blob/RC_2_0/src/magnet_uri.cpp)