### PR TITLE
Fix for Duplicate Uppercase/Lowercase Hashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,25 @@ function magnetURIDecode (uri) {
     // Clean up torrent name
     if (key === 'dn') val = decodeURIComponent(val).replace(/\+/g, ' ')
 
+    // Normalize BitTorrent info hashes in xt parameter to prevent duplicates
+    if (key === 'xt') {
+      // Check for btih with 40-char hex hash
+      const btih40Match = val.match(/^(urn:btih:)([0-9a-fA-F]{40})$/i)
+      if (btih40Match) {
+        val = btih40Match[1] + btih40Match[2].toLowerCase()
+      }
+      // Check for btih with 32-char base32 hash
+      const btih32Match = val.match(/^(urn:btih:)([0-9a-zA-Z]{32})$/i)
+      if (btih32Match) {
+        val = btih32Match[1] + btih32Match[2].toUpperCase()
+      }
+      // Check for btmh (BitTorrent v2) with 64-char hex hash
+      const btmhMatch = val.match(/^(urn:btmh:1220)([0-9a-fA-F]{64})$/i)
+      if (btmhMatch) {
+        val = btmhMatch[1] + btmhMatch[2].toLowerCase()
+      }
+    }
+
     // Address tracker (tr), exact source (xs), and acceptable source (as) are encoded
     // URIs, so decode them
     if (key === 'tr' || key === 'xs' || key === 'as' || key === 'ws') {


### PR DESCRIPTION
Fix for Issue #98.

In `magnetURIDecode`, the `xt` parameter is stored as-is in the result object:
```js
result.xt = 'urn:btih:2AA4F5A7E209E54B32803D43670971C4C8CAAA05'
```

The function then extracts the info hash and converts it to lowercase:
```js
if ((m = xt.match(/^urn:btih:(.{40})/))) {
  result.infoHash = m[1].toLowerCase()  // '2aa4f5a7e209e54b32803d43670971c4c8caaa05'
}
```

So the decoded object has both:
```
xt: 'urn:btih:2AA4F5A7E209E54B32803D43670971C4C8CAAA05' (original, uppercase)
infoHash: '2aa4f5a7e209e54b32803d43670971c4c8caaa05' (normalized, lowercase)
```

Then, in `magnetURIEncode`:

```js
let xts = new Set()
if (obj.xt && typeof obj.xt === 'string') xts.add(obj.xt)  // Adds uppercase version
// ...
if (obj.infoHash) xts.add(`urn:btih:${obj.infoHash}`)      // Adds lowercase version
```

Since the Set treats these as different strings (case-sensitive), both get added, resulting in duplicate `xt` parameters.

The issue should be fixed in the decode function by normalizing the `xt` parameter when it contains a BitTorrent info hash.

This fix ensures that:

1. All BitTorrent v1 hex info hashes (40 chars) are normalized to lowercase
2. All BitTorrent v1 base32 info hashes (32 chars) are normalized to uppercase (following base32 convention)
3. All BitTorrent v2 hex info hashes (64 chars) are normalized to lowercase
4. The normalization happens during decode, preventing duplicate `xt` parameters in the encoded output
5. Other `xt` URN types are left unchanged