### PR TITLE
fix: harden magnet URI decoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,26 +28,34 @@ function magnetURIDecode (uri) {
     const key = keyval[0]
     let val = keyval[1]
 
-    // Clean up torrent name
-    if (key === 'dn') val = decodeURIComponent(val).replace(/\+/g, ' ')
+    try {
+      // Clean up torrent name. Replace separators before decoding so an encoded
+      // literal plus sign (%2B) is preserved.
+      if (key === 'dn') val = decodeURIComponent(val.replace(/\+/g, ' '))
 
-    // Address tracker (tr), exact source (xs), and acceptable source (as) are encoded
-    // URIs, so decode them
-    if (key === 'tr' || key === 'xs' || key === 'as' || key === 'ws') {
-      val = decodeURIComponent(val)
+      // Address tracker (tr), exact source (xs), and acceptable source (as) are encoded
+      // URIs, so decode them
+      if (key === 'tr' || key === 'xs' || key === 'as' || key === 'ws') {
+        val = decodeURIComponent(val)
+      }
+
+      // Return keywords as an array. Split before decoding to preserve %2B.
+      if (key === 'kt') val = val.split('+').map(decodeURIComponent)
+
+      // Cast file index (ix) to a number
+      if (key === 'ix') val = Number(val)
+
+      // bep53
+      if (key === 'so') val = parse(decodeURIComponent(val).split(','))
+    } catch (err) {
+      // Ignore parameters with malformed percent encoding, as with other
+      // invalid parameters in a magnet URI.
+      if (err instanceof URIError) return
+      throw err
     }
 
-    // Return keywords as an array
-    if (key === 'kt') val = decodeURIComponent(val).split('+')
-
-    // Cast file index (ix) to a number
-    if (key === 'ix') val = Number(val)
-
-    // bep53
-    if (key === 'so') val = parse(decodeURIComponent(val).split(','))
-
     // If there are repeated parameters, return an array of values
-    if (result[key]) {
+    if (Object.prototype.hasOwnProperty.call(result, key)) {
       if (!Array.isArray(result[key])) {
         result[key] = [result[key]]
       }
@@ -63,11 +71,11 @@ function magnetURIDecode (uri) {
   if (result.xt) {
     const xts = Array.isArray(result.xt) ? result.xt : [result.xt]
     xts.forEach(xt => {
-      if ((m = xt.match(/^urn:btih:(.{40})/))) {
+      if ((m = xt.match(/^urn:btih:([a-f\d]{40})$/i))) {
         result.infoHash = m[1].toLowerCase()
-      } else if ((m = xt.match(/^urn:btih:(.{32})/))) {
+      } else if ((m = xt.match(/^urn:btih:([a-z2-7]{32})$/i))) {
         result.infoHash = arr2hex(decode(m[1]))
-      } else if ((m = xt.match(/^urn:btmh:1220(.{64})/))) {
+      } else if ((m = xt.match(/^urn:btmh:1220([a-f\d]{64})$/i))) {
         result.infoHashV2 = m[1].toLowerCase()
       }
     })
@@ -76,7 +84,7 @@ function magnetURIDecode (uri) {
   if (result.xs) {
     const xss = Array.isArray(result.xs) ? result.xs : [result.xs]
     xss.forEach(xs => {
-      if ((m = xs.match(/^urn:btpk:(.{64})/))) {
+      if ((m = xs.match(/^urn:btpk:([a-f\d]{64})$/i))) {
         result.publicKey = m[1].toLowerCase()
       }
     })

--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ function magnetURIDecode (uri) {
     const key = keyval[0]
     let val = keyval[1]
 
+    // Ignore keys that can alter object internals when assigned from untrusted
+    // input.
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') return
+
     try {
       // Clean up torrent name. Replace separators before decoding so an encoded
       // literal plus sign (%2B) is preserved.

--- a/test/decode.js
+++ b/test/decode.js
@@ -57,6 +57,17 @@ test('decode: repeated empty values are preserved', t => {
   t.end()
 })
 
+test('decode: ignores prototype-pollution keys', t => {
+  const result = magnet('magnet:?__proto__=polluted&constructor=polluted&prototype=polluted&dn=valid')
+
+  t.equal(Object.getPrototypeOf(result), Object.prototype)
+  t.equal(Object.prototype.hasOwnProperty.call(result, '__proto__'), false)
+  t.equal(Object.prototype.hasOwnProperty.call(result, 'constructor'), false)
+  t.equal(Object.prototype.hasOwnProperty.call(result, 'prototype'), false)
+  t.equal(result.dn, 'valid')
+  t.end()
+})
+
 test('decode: encoded plus signs are preserved', t => {
   const result = magnet('magnet:?dn=a%2Bb+c&kt=a%2Bb+c')
 

--- a/test/decode.js
+++ b/test/decode.js
@@ -50,6 +50,32 @@ test('empty string as keys is okay', t => {
   t.end()
 })
 
+test('decode: repeated empty values are preserved', t => {
+  const result = magnet('magnet:?a=&a=x')
+
+  t.deepEqual(result.a, ['', 'x'])
+  t.end()
+})
+
+test('decode: encoded plus signs are preserved', t => {
+  const result = magnet('magnet:?dn=a%2Bb+c&kt=a%2Bb+c')
+
+  t.equal(result.dn, 'a+b c')
+  t.deepEqual(result.kt, ['a+b', 'c'])
+  t.end()
+})
+
+test('decode: malformed percent encoding is ignored', t => {
+  const result = magnet('magnet:?dn=%E0%A4%A&tr=%E0%A4%A&kt=%E0%A4%A&so=%E0%A4%A&ix=1')
+
+  t.equal(result.dn, undefined)
+  t.equal(result.tr, undefined)
+  t.equal(result.kt, undefined)
+  t.equal(result.so, undefined)
+  t.equal(result.ix, 1)
+  t.end()
+})
+
 test('decode: invalid magnet URIs return empty object', t => {
   const invalid1 = 'magnet:?xt=urn:btih:==='
   const invalid2 = 'magnet:?xt'
@@ -77,6 +103,19 @@ test('decode: invalid magnet URIs return only valid keys (ignoring invalid ones)
 test('decode: extracts 40-char hex BitTorrent info_hash', t => {
   const result = magnet('magnet:?xt=urn:btih:aad050ee1bb22e196939547b134535824dabf0ce')
   t.equal(result.infoHash, 'aad050ee1bb22e196939547b134535824dabf0ce')
+  t.end()
+})
+
+test('decode: rejects invalid or trailing hash data', t => {
+  const invalidHex = magnet('magnet:?xt=urn:btih:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz')
+  const trailingV1 = magnet('magnet:?xt=urn:btih:aad050ee1bb22e196939547b134535824dabf0cex')
+  const trailingV2 = magnet('magnet:?xt=urn:btmh:122080e00d84343afd2b6392e966c1267807461946ba9db1d5af4bb50779dcf1ab4ex')
+  const invalidPublicKey = magnet('magnet:?xs=urn:btpk:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz')
+
+  t.equal(invalidHex.infoHash, undefined)
+  t.equal(trailingV1.infoHash, undefined)
+  t.equal(trailingV2.infoHashV2, undefined)
+  t.equal(invalidPublicKey.publicKey, undefined)
   t.end()
 })
 


### PR DESCRIPTION
## Summary

- ignore parameters with malformed percent encoding instead of throwing
- preserve percent-encoded literal plus signs in names and keywords
- preserve repeated parameters whose first value is empty
- strictly validate v1/v2 info hashes and BEP46 public keys
- add regression coverage for each case

## Testing

- `XDG_CACHE_HOME=/tmp/magnet-uri-cache npm test` (71 assertions pass)
- `git diff --check`